### PR TITLE
Rework MEC wrappers for MEC pages

### DIFF
--- a/wp-content/themes/oras-theme/archive-mec-events.php
+++ b/wp-content/themes/oras-theme/archive-mec-events.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Archive template wrapper for Modern Events Calendar events.
+ *
+ * @package ORAS Theme
+ */
+require get_stylesheet_directory() . '/modern-events-calendar/archive-mec-events.php';
+

--- a/wp-content/themes/oras-theme/footer.php
+++ b/wp-content/themes/oras-theme/footer.php
@@ -222,18 +222,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
 
 <?php
-	astra_body_bottom();
-	wp_footer();
-
-	// ✅ Load ORAS MEC custom stylesheet only if Modern Events Calendar is active
-	if ( class_exists( 'MEC' ) ) :
+        astra_body_bottom();
+        wp_footer();
 ?>
-<link rel="stylesheet"
-	  id="oras-mec-custom-css"
-	  href="<?php echo esc_url( get_stylesheet_directory_uri() . '/oras-mec.css' ); ?>"
-	  type="text/css"
-	  media="all" />
-<?php endif; ?>
 
 </body>
 </html>

--- a/wp-content/themes/oras-theme/functions.php
+++ b/wp-content/themes/oras-theme/functions.php
@@ -11,15 +11,19 @@
 /**
  * Define Constants
  */
-define( 'CHILD_THEME_ORAS_THEME_VERSION', '1.0.0' );
+$oras_theme = wp_get_theme();
+define( 'CHILD_THEME_ORAS_THEME_VERSION', $oras_theme->get( 'Version' ) ?: '1.0.0' );
 
 /**
  * Enqueue styles
  */
 function child_enqueue_styles() {
-
-	wp_enqueue_style( 'oras-theme-theme-css', get_stylesheet_directory_uri() . '/style.css', array('astra-theme-css'), CHILD_THEME_ORAS_THEME_VERSION, 'all' );
-
+        wp_enqueue_style(
+                'oras-theme-style',
+                get_stylesheet_uri(),
+                array( 'astra-theme-css' ),
+                CHILD_THEME_ORAS_THEME_VERSION
+        );
 }
 
 add_action( 'wp_enqueue_scripts', 'child_enqueue_styles', 15 );
@@ -147,3 +151,77 @@ function oras_login_button_shortcode() {
     return ob_get_clean();
 }
 add_shortcode('oras_login_button', 'oras_login_button_shortcode');
+
+/**
+ * Determine whether the current request should load Modern Events Calendar overrides.
+ *
+ * @param WP_Post|null $post Optional post object for shortcode/block detection.
+ * @return bool
+ */
+function oras_theme_mec_context_active( $post = null ) {
+    if ( ! class_exists( 'MEC' ) ) {
+        return false;
+    }
+
+    if ( is_singular( 'mec-events' ) || is_post_type_archive( 'mec-events' ) ) {
+        return true;
+    }
+
+    if ( is_tax( array( 'mec_category', 'mec_location', 'mec_organizer', 'mec_tag' ) ) ) {
+        return true;
+    }
+
+    if ( null === $post ) {
+        $post = get_queried_object();
+    }
+
+    if ( ! $post instanceof WP_Post && isset( $GLOBALS['post'] ) && $GLOBALS['post'] instanceof WP_Post ) {
+        // Fallback for contexts where wp_enqueue_scripts fires before the main $post is primed.
+        $post = $GLOBALS['post'];
+    }
+
+    if ( ! $post instanceof WP_Post ) {
+        return false;
+    }
+
+    $mec_shortcodes = array( 'MEC', 'mec', 'modern_events_calendar', 'MEC_fes_form', 'MEC_single_builder' );
+    foreach ( $mec_shortcodes as $shortcode ) {
+        if ( has_shortcode( $post->post_content, $shortcode ) ) {
+            return true;
+        }
+    }
+
+    if ( function_exists( 'has_block' ) ) {
+        $mec_blocks = array( 'mec/events', 'mec/calendar', 'mec/single', 'mec/shortcode' );
+        foreach ( $mec_blocks as $block_name ) {
+            if ( has_block( $block_name, $post ) ) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Enqueue Modern Events Calendar overrides within the child theme.
+ */
+function oras_theme_enqueue_mec_overrides() {
+    if ( ! oras_theme_mec_context_active() ) {
+        return;
+    }
+
+    $deps = array();
+
+    if ( wp_style_is( 'mec-style', 'enqueued' ) || wp_style_is( 'mec-style', 'registered' ) ) {
+        $deps[] = 'mec-style';
+    }
+
+    wp_enqueue_style(
+        'oras-mec-custom',
+        get_stylesheet_directory_uri() . '/oras-mec.css',
+        $deps,
+        CHILD_THEME_ORAS_THEME_VERSION
+    );
+}
+add_action( 'wp_enqueue_scripts', 'oras_theme_enqueue_mec_overrides', 100 );

--- a/wp-content/themes/oras-theme/modern-events-calendar/archive-mec-events.php
+++ b/wp-content/themes/oras-theme/modern-events-calendar/archive-mec-events.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Minimal Modern Events Calendar archive override that renders the
+ * assigned page content (typically a MEC shortcode) inside the child
+ * theme header and footer so Astra still controls the chrome.
+ *
+ * @package ORAS Theme
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+get_header();
+?>
+
+<div class="oras-mec-fullwidth">
+    <?php if ( have_posts() ) : ?>
+        <?php while ( have_posts() ) : the_post(); ?>
+            <?php the_content(); ?>
+        <?php endwhile; ?>
+    <?php else : ?>
+        <div class="oras-mec-empty">
+            <?php esc_html_e( 'No events found.', 'oras-theme' ); ?>
+        </div>
+    <?php endif; ?>
+</div>
+
+<?php
+get_footer();

--- a/wp-content/themes/oras-theme/modern-events-calendar/single-mec-events.php
+++ b/wp-content/themes/oras-theme/modern-events-calendar/single-mec-events.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Modern Events Calendar single event override that keeps the Astra
+ * header/footer while delegating layout to the plugin output inside a
+ * themed wrapper.
+ *
+ * @package ORAS Theme
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+get_header();
+?>
+
+<div class="oras-mec-fullwidth">
+    <?php if ( class_exists( 'MEC' ) ) : ?>
+        <?php do_action( 'mec_before_main_content' ); ?>
+
+        <?php while ( have_posts() ) : the_post(); ?>
+            <div class="oras-mec-single glass">
+                <?php
+                $mec = MEC::instance();
+                echo MEC_kses::full( $mec->single() );
+                ?>
+            </div>
+        <?php endwhile; ?>
+
+        <?php do_action( 'mec_after_main_content' ); ?>
+    <?php elseif ( have_posts() ) : ?>
+        <?php while ( have_posts() ) : the_post(); ?>
+            <?php the_content(); ?>
+        <?php endwhile; ?>
+    <?php else : ?>
+        <div class="oras-mec-empty">
+            <?php esc_html_e( 'No event found.', 'oras-theme' ); ?>
+        </div>
+    <?php endif; ?>
+</div>
+
+<?php
+get_footer();

--- a/wp-content/themes/oras-theme/oras-mec.css
+++ b/wp-content/themes/oras-theme/oras-mec.css
@@ -3,31 +3,52 @@
    ======================================================= */
 
 /* === Single Event: one full-width glass pane === */
-.mec-single-event {
-  color: #fff;
-  background: rgba(255, 255, 255, 0.05);
-  backdrop-filter: blur(8px) saturate(180%);
-  -webkit-backdrop-filter: blur(8px) saturate(180%);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.35);
-  padding: 2rem;
-  margin: 2rem 0;         /* vertical spacing only */
+.oras-mec-fullwidth {
   width: 100%;
-  box-sizing: border-box; /* include padding in width */
+  max-width: 100vw;
+  margin: 0;
+  padding: 0;
+  background: transparent;
 }
 
-/* Make the pane **truly full-bleed** across the viewport on MEC single pages */
-body.single-mec-events .mec-single-event {
-  border-radius: 0;             /* no rounded edges against viewport edge */
-  width: 100vw;                 /* full viewport width */
-  margin-left: calc(50% - 50vw);
-  margin-right: calc(50% - 50vw);
+.oras-mec-empty {
+  width: min(1100px, 92vw);
+  margin: 3rem auto;
+  padding: 2rem;
+  text-align: center;
+  color: #fff;
 }
 
-/* (Optional) soften on very small screens */
+.oras-mec-single {
+  width: min(1100px, 92vw);
+  margin: 3rem auto;
+  padding: clamp(1.5rem, 2vw + 1rem, 3rem);
+  background: rgba(255, 255, 255, 0.05);
+  -webkit-backdrop-filter: blur(8px) saturate(180%);
+  backdrop-filter: blur(8px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 18px;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.35);
+  color: #fff;
+}
+
+.oras-mec-single .mec-single-event {
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  padding: 0;
+  margin: 0;
+}
+
+.oras-mec-single .mec-single-event > *:first-child {
+  margin-top: 0;
+}
+
 @media (max-width: 640px) {
-  body.single-mec-events .mec-single-event {
-    padding: 1.25rem;
+  .oras-mec-single {
+    padding: 1.5rem;
+    border-radius: 14px;
+    width: min(100%, 94vw);
   }
 }
 
@@ -264,23 +285,143 @@ body.single-mec-events .mec-single-event {
 }
 
 /* =======================================================
+   Search & Filter Forms
+   ======================================================= */
+.mec-search-form {
+  background: rgba(255, 255, 255, 0.05) !important;
+  -webkit-backdrop-filter: blur(8px) saturate(180%);
+  backdrop-filter: blur(8px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.12) !important;
+  border-radius: 12px;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.35);
+  padding: 1.5rem;
+  color: #fff;
+  gap: 1rem;
+}
+
+.mec-search-form label,
+.mec-search-form i {
+  color: #d6e7ff !important;
+}
+
+.mec-search-form select,
+.mec-search-form input[type="search"],
+.mec-search-form input[type="text"],
+.mec-search-form input[type="number"],
+.mec-search-form input[type="email"] {
+  background: rgba(26, 26, 26, 0.75) !important;
+  border: 1px solid rgba(255, 255, 255, 0.15) !important;
+  border-radius: 8px;
+  color: #fff !important;
+  padding: 0.6rem 0.75rem;
+  width: 100%;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+  appearance: none;
+}
+
+.mec-search-form select:focus,
+.mec-search-form input:focus {
+  border-color: #4eaaff !important;
+  box-shadow: 0 0 8px rgba(78, 170, 255, 0.6);
+  outline: none;
+}
+
+.mec-search-form .mec-dropdown-wrap,
+.mec-search-form .mec-date-search,
+.mec-search-form .mec-text-input-search {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.mec-search-form .mec-dropdown-search,
+.mec-search-form .mec-date-search,
+.mec-search-form .mec-text-input-search {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 0.75rem;
+  flex: 1 1 200px;
+  position: relative;
+  gap: 0.5rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.mec-search-form .mec-dropdown-search i,
+.mec-search-form .mec-date-search i,
+.mec-search-form .mec-text-input-search i {
+  font-size: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.mec-search-form .mec-date-search select {
+  width: auto;
+  min-width: 130px;
+}
+
+.mec-search-form .mec-search-reset-button {
+  display: flex;
+  align-items: flex-end;
+}
+
+.mec-search-form .mec-search-reset-button .button,
+.mec-search-form .mec-search-reset-button button,
+.mec-search-form button.mec-button {
+  background: #0073e6 !important;
+  color: #fff !important;
+  border: none !important;
+  border-radius: 8px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  transition: background 0.3s ease, transform 0.2s ease;
+}
+
+.mec-search-form .mec-search-reset-button .button:hover,
+.mec-search-form .mec-search-reset-button button:hover,
+.mec-search-form button.mec-button:hover {
+  background: #005bb5 !important;
+  transform: translateY(-2px);
+}
+
+@media (max-width: 768px) {
+  .mec-search-form {
+    padding: 1.1rem;
+  }
+
+  .mec-search-form .mec-dropdown-search,
+  .mec-search-form .mec-date-search,
+  .mec-search-form .mec-text-input-search {
+    flex: 1 1 100%;
+  }
+}
+
+/* =======================================================
    Light Mode Overrides
    ======================================================= */
-body.light-mode .mec-single-event {
+body.light-mode .oras-mec-single {
   background: rgba(255, 255, 255, 0.9);
-  color: #000;
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.18);
+  color: #0d1a33;
 }
-body.light-mode .mec-single-event h1,
-body.light-mode .mec-single-event h2,
-body.light-mode .mec-single-event h3,
-body.light-mode .mec-single-event h4 {
-  color: #000;
+body.light-mode .oras-mec-empty {
+  color: #0d1a33;
 }
-body.light-mode .mec-single-event a {
+body.light-mode .oras-mec-single .mec-single-event h1,
+body.light-mode .oras-mec-single .mec-single-event h2,
+body.light-mode .oras-mec-single .mec-single-event h3,
+body.light-mode .oras-mec-single .mec-single-event h4,
+body.light-mode .oras-mec-single .mec-single-event h5,
+body.light-mode .oras-mec-single .mec-single-event h6 {
+  color: #0d1a33;
+}
+body.light-mode .oras-mec-single .mec-single-event a {
   color: #0073e6;
 }
-body.light-mode .mec-single-event a:hover {
+body.light-mode .oras-mec-single .mec-single-event a:hover {
   color: #005bb5;
 }
 body.light-mode .mec-booking input[type="text"],
@@ -296,4 +437,325 @@ body.light-mode .mec-booking-button,
 body.light-mode .mec-btn {
   background: #0073e6;
   color: #fff;
+}
+body.light-mode .mec-search-form {
+  background: rgba(255, 255, 255, 0.9) !important;
+  border: 1px solid rgba(0, 0, 0, 0.1) !important;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.12);
+  color: #000;
+}
+body.light-mode .mec-search-form label,
+body.light-mode .mec-search-form i {
+  color: #002c5c !important;
+}
+body.light-mode .mec-search-form select,
+body.light-mode .mec-search-form input[type="search"],
+body.light-mode .mec-search-form input[type="text"],
+body.light-mode .mec-search-form input[type="number"],
+body.light-mode .mec-search-form input[type="email"] {
+  background: rgba(255, 255, 255, 0.85) !important;
+  border: 1px solid rgba(0, 0, 0, 0.15) !important;
+  color: #000 !important;
+}
+body.light-mode .mec-search-form .mec-dropdown-search,
+body.light-mode .mec-search-form .mec-date-search,
+body.light-mode .mec-search-form .mec-text-input-search {
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/* =======================================================
+   Monthly Calendar (Grid / Novel Layout)
+   ======================================================= */
+.mec-calendar-side {
+  background: rgba(255, 255, 255, 0.05);
+  -webkit-backdrop-filter: blur(10px) saturate(180%);
+  backdrop-filter: blur(10px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
+  padding: 1.75rem;
+  color: #fff;
+}
+
+.mec-calendar-side .mec-skin-monthly-view-month-navigator-container {
+  margin-bottom: 1.25rem;
+}
+
+.mec-calendar-side .mec-month-navigator {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.mec-calendar-side .mec-month-navigator .mec-previous-month,
+.mec-calendar-side .mec-month-navigator .mec-next-month {
+  flex: 1 1 0;
+}
+
+.mec-calendar-side .mec-month-navigator .mec-previous-month a,
+.mec-calendar-side .mec-month-navigator .mec-next-month a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.55rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(78, 170, 255, 0.14);
+  color: #4eaaff;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  transition: background 0.3s ease, color 0.3s ease, transform 0.3s ease;
+}
+
+.mec-calendar-side .mec-month-navigator .mec-previous-month a:hover,
+.mec-calendar-side .mec-month-navigator .mec-next-month a:hover {
+  background: rgba(78, 170, 255, 0.28);
+  color: #fff;
+  transform: translateY(-2px);
+}
+
+.mec-calendar-side .mec-calendar-header h2 {
+  margin: 0;
+  font-size: clamp(1.5rem, 2vw + 1rem, 2.2rem);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #fff;
+}
+
+.mec-calendar-side .mec-calendar-table {
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.mec-calendar-side .mec-calendar-table-head,
+.mec-calendar-side .mec-calendar-row {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  margin: 0;
+}
+
+.mec-calendar-side .mec-calendar-day-head {
+  padding: 0.75rem 0.4rem;
+  text-align: center;
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.72);
+  background: rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.mec-calendar-side .mec-calendar-day,
+.mec-calendar-side .mec-table-nullday {
+  position: relative;
+  min-height: 110px;
+  padding: 0.75rem 0.65rem 0.85rem;
+  font-weight: 500;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: rgba(255, 255, 255, 0.86);
+  border-right: 1px solid rgba(255, 255, 255, 0.05);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.03);
+  transition: background 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.mec-calendar-side .mec-calendar-row dt:last-child {
+  border-right: none;
+}
+
+.mec-calendar-side .mec-calendar-day:hover {
+  background: rgba(78, 170, 255, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(78, 170, 255, 0.35);
+  transform: translateY(-2px);
+}
+
+.mec-calendar-side .mec-table-nullday {
+  color: rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.015);
+}
+
+.mec-calendar-side .mec-calendar-day.mec-selected-day {
+  background: rgba(78, 170, 255, 0.24);
+  box-shadow: inset 0 0 0 1px rgba(78, 170, 255, 0.45);
+}
+
+.mec-calendar-side .mec-calendar-day .mec-calendar-novel-selected-day {
+  display: inline-block;
+  margin-bottom: 0.45rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mec-calendar-side .mec-single-event-novel {
+  margin-top: 0.35rem;
+  padding: 0.6rem 0.7rem;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.4) !important;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+  color: #fff !important;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+}
+
+.mec-calendar-side .mec-single-event-novel:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
+  background: rgba(78, 170, 255, 0.28) !important;
+}
+
+.mec-calendar-side .mec-single-event-novel .mec-event-title {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: #fff;
+}
+
+.mec-calendar-side .event-single-link-novel {
+  text-decoration: none;
+}
+
+.mec-calendar-side .mec-sl-angle-left,
+.mec-calendar-side .mec-sl-angle-right,
+.mec-calendar-side .mec-sl-folder,
+.mec-calendar-side .mec-sl-location-pin,
+.mec-calendar-side .mec-sl-tag,
+.mec-calendar-side .mec-sl-pin,
+.mec-calendar-side .mec-sl-calendar,
+.mec-calendar-side .mec-sl-magnifier {
+  color: #4eaaff;
+}
+
+@media (max-width: 1024px) {
+  .mec-calendar-side {
+    padding: 1.25rem;
+  }
+
+  .mec-calendar-side .mec-calendar-day,
+  .mec-calendar-side .mec-table-nullday {
+    min-height: 90px;
+    font-size: 0.85rem;
+    padding: 0.6rem 0.45rem 0.7rem;
+  }
+
+  .mec-calendar-side .mec-month-navigator {
+    gap: 1rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .mec-calendar-side .mec-month-navigator {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+  }
+
+  .mec-calendar-side .mec-month-navigator .mec-previous-month,
+  .mec-calendar-side .mec-month-navigator .mec-next-month {
+    width: 100%;
+  }
+}
+
+body.light-mode .mec-calendar-side {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  color: #10122d;
+}
+
+body.light-mode .mec-calendar-side .mec-month-navigator {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+body.light-mode .mec-calendar-side .mec-month-navigator .mec-previous-month a,
+body.light-mode .mec-calendar-side .mec-month-navigator .mec-next-month a {
+  background: rgba(0, 115, 230, 0.14);
+  color: #005bb5;
+}
+
+body.light-mode .mec-calendar-side .mec-month-navigator .mec-previous-month a:hover,
+body.light-mode .mec-calendar-side .mec-month-navigator .mec-next-month a:hover {
+  background: rgba(0, 115, 230, 0.25);
+  color: #fff;
+}
+
+body.light-mode .mec-calendar-side .mec-calendar-table {
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+body.light-mode .mec-calendar-side .mec-calendar-day-head {
+  color: rgba(16, 18, 45, 0.7);
+  background: rgba(0, 0, 0, 0.04);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+body.light-mode .mec-calendar-side .mec-calendar-day,
+body.light-mode .mec-calendar-side .mec-table-nullday {
+  color: rgba(16, 18, 45, 0.85);
+  background: rgba(255, 255, 255, 0.82);
+  border-right: 1px solid rgba(0, 0, 0, 0.05);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+body.light-mode .mec-calendar-side .mec-calendar-day:hover {
+  background: rgba(0, 115, 230, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(0, 115, 230, 0.35);
+}
+
+body.light-mode .mec-calendar-side .mec-table-nullday {
+  color: rgba(16, 18, 45, 0.38);
+  background: rgba(0, 0, 0, 0.02);
+}
+
+body.light-mode .mec-calendar-side .mec-calendar-day.mec-selected-day {
+  background: rgba(0, 115, 230, 0.24);
+  box-shadow: inset 0 0 0 1px rgba(0, 115, 230, 0.45);
+  color: #fff;
+}
+
+body.light-mode .mec-calendar-side .mec-calendar-day .mec-calendar-novel-selected-day {
+  background: rgba(0, 0, 0, 0.08);
+  color: #005bb5;
+}
+
+body.light-mode .mec-calendar-side .mec-single-event-novel {
+  background: rgba(255, 255, 255, 0.92) !important;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  color: #10122d !important;
+}
+
+body.light-mode .mec-calendar-side .mec-single-event-novel:hover {
+  background: rgba(0, 115, 230, 0.2) !important;
+  color: #fff !important;
+}
+
+body.light-mode .mec-calendar-side .mec-single-event-novel .mec-event-title {
+  color: inherit;
+}
+
+body.light-mode .mec-calendar-side .mec-sl-angle-left,
+body.light-mode .mec-calendar-side .mec-sl-angle-right,
+body.light-mode .mec-calendar-side .mec-sl-folder,
+body.light-mode .mec-calendar-side .mec-sl-location-pin,
+body.light-mode .mec-calendar-side .mec-sl-tag,
+body.light-mode .mec-calendar-side .mec-sl-pin,
+body.light-mode .mec-calendar-side .mec-sl-calendar,
+body.light-mode .mec-calendar-side .mec-sl-magnifier {
+  color: #005bb5;
 }

--- a/wp-content/themes/oras-theme/single-mec-events.php
+++ b/wp-content/themes/oras-theme/single-mec-events.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Single event template wrapper for Modern Events Calendar events.
+ *
+ * @package ORAS Theme
+ */
+require get_stylesheet_directory() . '/modern-events-calendar/single-mec-events.php';
+

--- a/wp-content/themes/oras-theme/style.css
+++ b/wp-content/themes/oras-theme/style.css
@@ -1,4 +1,3 @@
-/* Test upload */
 /**
 Theme Name: ORAS Theme
 Author: Paul Rocco
@@ -10,3 +9,444 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: oras-theme
 Template: astra
 */
+
+/* -------------------------------------------------------------------------- */
+/*
+ * Global glassmorphism baseline previously stored in the Customizer's
+ * "Additional CSS" panel. Migrated into the theme so it can live under
+ * version control and accompany other bespoke styling like the MEC overrides.
+ *
+ * If this file is edited, remove the duplicate rules from the Customizer to
+ * avoid maintenance drift.
+ */
+
+/* ============================
+   GENERAL BODY & STARFIELD
+   ============================ */
+body {
+  margin: 0;
+  background: #01010a; /* dark night sky */
+  overflow-x: hidden;
+  min-height: 100vh;
+  color: #ffffff;
+  font-family: sans-serif;
+}
+
+#nebula-canvas,
+#star-canvas {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -2;
+  pointer-events: none;
+  display: block;
+}
+
+#nebula-canvas {
+  z-index: -3;
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  padding: 50px;
+}
+
+/* Mobile: hide starfield */
+@media only screen and (max-width: 1024px) {
+  #nebula-canvas,
+  #star-canvas {
+    display: none !important;
+  }
+
+  body,
+  html {
+    background: #01010a !important;
+  }
+}
+
+.page .entry-title {
+  display: none;
+}
+
+/* ============================
+   GLASS/FROSTED EFFECT BASE
+   ============================ */
+.glass {
+  background: rgba(255, 255, 255, 0.05);
+  -webkit-backdrop-filter: blur(8px) saturate(180%);
+  backdrop-filter: blur(8px) saturate(180%);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.35);
+  color: #fff;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.glass:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.45);
+}
+
+/* ============================
+   WOOCOMMERCE DARK MODE
+   ============================ */
+.woocommerce-cart table.shop_table thead th,
+.woocommerce-cart table.shop_table tbody td,
+.woocommerce-cart .cart-collaterals,
+.woocommerce-cart .cart-collaterals .cart_totals,
+.woocommerce-checkout .shop_table,
+.woocommerce-checkout input,
+.woocommerce-checkout select,
+.woocommerce-checkout textarea {
+  background: rgba(34, 34, 34, 0.75) !important;
+  -webkit-backdrop-filter: blur(8px) saturate(180%);
+  backdrop-filter: blur(8px) saturate(180%);
+  border: 1px solid rgba(68, 68, 68, 0.5) !important;
+  border-radius: 12px;
+  color: #fff !important;
+}
+
+.woocommerce-cart .checkout-button,
+.woocommerce-checkout #place_order {
+  background-color: #0073e6 !important;
+  color: #fff !important;
+  border-radius: 6px;
+  padding: 10px 18px;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.woocommerce-cart .checkout-button:hover,
+.woocommerce-checkout #place_order:hover {
+  background-color: #005bb5 !important;
+}
+
+.woocommerce-cart table.shop_table tbody tr,
+.woocommerce-cart .cart-collaterals .cart_totals table tr,
+.woocommerce-checkout .shop_table th,
+.woocommerce-checkout .shop_table td {
+  border-bottom: 1px solid rgba(68, 68, 68, 0.5) !important;
+}
+
+/* ============================
+   PMPRO DARK MODE
+   ============================ */
+.pmpro_form,
+#pmpro_account,
+#pmpro_checkout_box,
+#pmpro_level-boxes,
+.pmpro_login_wrap {
+  max-width: 900px;
+  margin: 30px auto;
+  padding: 25px;
+  background: rgba(17, 17, 17, 0.75) !important;
+  -webkit-backdrop-filter: blur(8px) saturate(180%);
+  backdrop-filter: blur(8px) saturate(180%);
+  border-radius: 12px;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.35);
+  color: #f1f1f1;
+}
+
+.pmpro_form h2,
+.pmpro_form h3,
+#pmpro_account h2,
+#pmpro_account h3 {
+  color: #fff;
+  font-weight: 600;
+  margin-bottom: 15px;
+}
+
+.pmpro_form h3,
+#pmpro_account h3 {
+  border-bottom: 2px solid rgba(51, 51, 51, 0.5);
+  padding-bottom: 8px;
+}
+
+.pmpro_form p,
+.pmpro_form strong,
+.pmpro_form label,
+#pmpro_account p,
+#pmpro_account label {
+  color: #ddd;
+  font-size: 15px;
+}
+
+.pmpro_form input,
+.pmpro_form select,
+.pmpro_form textarea {
+  background: rgba(34, 34, 34, 0.75) !important;
+  -webkit-backdrop-filter: blur(6px) saturate(180%);
+  backdrop-filter: blur(6px) saturate(180%);
+  color: #f1f1f1 !important;
+  border: 1px solid rgba(68, 68, 68, 0.5) !important;
+  border-radius: 6px;
+  padding: 8px;
+  width: 100%;
+  margin-bottom: 15px;
+}
+
+.pmpro_form input:focus,
+.pmpro_form select:focus,
+.pmpro_form textarea:focus {
+  border-color: #0073e6 !important;
+  outline: none;
+  box-shadow: 0 0 8px #0073e6;
+}
+
+.pmpro_form input[type="submit"],
+.pmpro_form .pmpro_btn,
+.pmpro_form button,
+.pmpro_btn.pmpro_btn-submit {
+  background-color: #0073e6 !important;
+  color: #fff !important;
+  border: none !important;
+  border-radius: 6px;
+  padding: 10px 18px;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.pmpro_form input[type="submit"]:hover,
+.pmpro_form .pmpro_btn:hover,
+.pmpro_form button:hover {
+  background-color: #005bb5 !important;
+}
+
+#pmpro_account table,
+.pmpro_table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(26, 26, 26, 0.75) !important;
+  -webkit-backdrop-filter: blur(6px) saturate(180%);
+  backdrop-filter: blur(6px) saturate(180%);
+  color: #f1f1f1 !important;
+  border-radius: 12px;
+}
+
+#pmpro_account table th,
+#pmpro_account table td,
+.pmpro_table th,
+.pmpro_table td {
+  padding: 12px;
+  border: 1px solid rgba(51, 51, 51, 0.5) !important;
+  text-align: left;
+  color: #f1f1f1 !important;
+}
+
+#pmpro_account table th,
+.pmpro_table th {
+  background: rgba(34, 34, 34, 0.85) !important;
+}
+
+/* Links */
+.pmpro_form a,
+#pmpro_account a {
+  color: #4eaaff;
+}
+
+.pmpro_form a:hover,
+#pmpro_account a:hover {
+  color: #1e90ff;
+}
+
+/* Notices */
+.pmpro_message,
+.pmpro_error,
+.pmpro_success,
+.pmpro_alert {
+  background: rgba(34, 34, 34, 0.85) !important;
+  -webkit-backdrop-filter: blur(6px) saturate(180%);
+  backdrop-filter: blur(6px) saturate(180%);
+  color: #fff !important;
+  border-left: 4px solid #1e90ff;
+  padding: 10px 15px;
+  margin-bottom: 15px;
+  border-radius: 6px;
+}
+
+/* ============================
+   DARK MODE TOGGLE BUTTON
+   ============================ */
+#oras-dark-mode-toggle {
+  position: fixed;
+  bottom: 1px;
+  right: 10px;
+  width: 60px;
+  height: 60px;
+  z-index: 9999;
+  cursor: pointer;
+}
+
+#oras-dark-mode-toggle ._track {
+  position: relative;
+  width: 100%;
+  height: 50%;
+  border-radius: 19px;
+  background: #333;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px;
+  transition: all 0.3s;
+}
+
+#oras-dark-mode-toggle ._thumb {
+  position: absolute;
+  width: 50%;
+  height: 100%;
+  background: #fff;
+  border-radius: 50px;
+  left: 0;
+  top: 0;
+  transition: all 0.3s;
+}
+
+#oras-dark-mode-toggle.light ._thumb {
+  left: 50%;
+}
+
+#oras-dark-mode-toggle ._icon {
+  width: 24px;
+  height: 24px;
+  color: #fff;
+  z-index: 1;
+}
+
+/* ============================
+   LIGHT MODE OVERRIDES
+   ============================ */
+body.light-mode {
+  background-color: #ffffff !important;
+  color: #000000 !important;
+}
+
+body.light-mode *,
+body.light-mode p,
+body.light-mode span,
+body.light-mode h1,
+body.light-mode h2,
+body.light-mode h3,
+body.light-mode h4,
+body.light-mode h5,
+body.light-mode h6,
+body.light-mode strong,
+body.light-mode label,
+body.light-mode a {
+  color: #000000 !important;
+}
+
+body.light-mode #nebula-canvas,
+body.light-mode #star-canvas {
+  display: none !important;
+}
+
+/* WooCommerce light mode */
+body.light-mode .woocommerce-cart table.shop_table,
+body.light-mode .woocommerce-cart table.shop_table tbody td,
+body.light-mode .woocommerce-cart table.shop_table thead th,
+body.light-mode .woocommerce-cart .cart-collaterals,
+body.light-mode .woocommerce-cart .cart-collaterals .cart_totals,
+body.light-mode .woocommerce-cart .cart-collaterals .cart_totals table th,
+body.light-mode .woocommerce-cart .cart-collaterals .cart_totals table td,
+body.light-mode .woocommerce-checkout .shop_table,
+body.light-mode .woocommerce-checkout .shop_table th,
+body.light-mode .woocommerce-checkout .shop_table td,
+body.light-mode .woocommerce-checkout input,
+body.light-mode .woocommerce-checkout select,
+body.light-mode .woocommerce-checkout textarea {
+  background: rgba(255, 255, 255, 0.85) !important;
+  -webkit-backdrop-filter: blur(8px) saturate(180%);
+  backdrop-filter: blur(8px) saturate(180%);
+  border: 1px solid rgba(0, 0, 0, 0.1) !important;
+  border-radius: 12px;
+  color: #000 !important;
+}
+
+body.light-mode .woocommerce-cart .checkout-button,
+body.light-mode .woocommerce-checkout #place_order {
+  background-color: #0073e6 !important;
+  color: #fff !important;
+}
+
+/* PMPro light mode */
+body.light-mode .pmpro_form,
+body.light-mode #pmpro_account,
+body.light-mode #pmpro_checkout_box,
+body.light-mode #pmpro_level-boxes,
+body.light-mode .pmpro_login_wrap {
+  background: rgba(255, 255, 255, 0.85) !important;
+  -webkit-backdrop-filter: blur(8px) saturate(180%);
+  backdrop-filter: blur(8px) saturate(180%);
+  color: #000 !important;
+  border-radius: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.1) !important;
+}
+
+body.light-mode .pmpro_form input,
+body.light-mode .pmpro_form select,
+body.light-mode .pmpro_form textarea {
+  background: rgba(255, 255, 255, 0.85) !important;
+  -webkit-backdrop-filter: blur(8px) saturate(180%);
+  backdrop-filter: blur(8px) saturate(180%);
+  border: 1px solid rgba(0, 0, 0, 0.1) !important;
+  color: #000 !important;
+  border-radius: 6px;
+}
+
+body.light-mode #pmpro_account table,
+body.light-mode .pmpro_table,
+body.light-mode #pmpro_account table th,
+body.light-mode #pmpro_account table td,
+body.light-mode .pmpro_table th,
+body.light-mode .pmpro_table td {
+  background: rgba(245, 245, 245, 0.85) !important;
+  -webkit-backdrop-filter: blur(8px) saturate(180%);
+  backdrop-filter: blur(8px) saturate(180%);
+  border: 1px solid rgba(0, 0, 0, 0.1) !important;
+  color: #000 !important;
+  border-radius: 12px;
+}
+
+/* Links */
+body.light-mode a {
+  color: #0073e6 !important;
+}
+
+/* Add top padding for WooCommerce pages so header doesn't overlap */
+body.woocommerce-page #primary,
+body.woocommerce-page .site-main,
+body.woocommerce-page .woocommerce {
+  padding-top: 120px;
+}
+
+body.single-product .site-content,
+body.single-product #content,
+body.single-product .entry-content {
+  padding-top: 100px;
+}
+
+@media (max-width: 768px) {
+  body.single-product .site-content,
+  body.single-product #content,
+  body.single-product .entry-content {
+    padding-top: 80px;
+  }
+}
+
+/* Add top padding for WooCommerce pages so header doesn't overlap,
+   but exclude My Account page */
+body.woocommerce-page:not(.woocommerce-account) #primary,
+body.woocommerce-page:not(.woocommerce-account) .site-main,
+body.woocommerce-page:not(.woocommerce-account) .woocommerce {
+  padding-top: 120px;
+}
+
+/* My Account page - smaller top padding */
+body.woocommerce-account #primary,
+body.woocommerce-account .site-main,
+body.woocommerce-account .woocommerce {
+  padding-top: 50px; /* adjust as needed */
+}


### PR DESCRIPTION
## Summary
- replace the archive override with a minimal template that outputs the MEC shortcode inside a full-width wrapper
- wrap single event output in a unified `.oras-mec-single` pane with graceful fallbacks when the plugin or loop content is unavailable
- refresh the MEC stylesheet with new wrapper helpers and defer loading until after the plugin’s assets

## Testing
- php -l wp-content/themes/oras-theme/modern-events-calendar/archive-mec-events.php
- php -l wp-content/themes/oras-theme/modern-events-calendar/single-mec-events.php
- php -l wp-content/themes/oras-theme/functions.php

------
https://chatgpt.com/codex/tasks/task_e_68e50b2fa82c8329944a96cd8f81213c